### PR TITLE
rewrite subscription logic

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,104 @@
+root = true
+
+[*]
+indent_style = space
+indent_size = 4
+
+[*.{md, markdown, json, js, csproj, fsproj, targets, props}]
+indent_size = 2
+
+# Dotnet code style settings:
+[*.cs]
+
+trim_trailing_whitespace = true
+insert_final_newline = true
+
+# ---
+# naming conventions https://docs.microsoft.com/en-us/visualstudio/ide/editorconfig-naming-conventions
+# currently not supported in Rider/Resharper so not using these for now
+# ---
+
+# ---
+# language conventions https://docs.microsoft.com/en-us/visualstudio/ide/editorconfig-code-style-settings-reference#language-conventions
+
+# Sort using and Import directives with System.* appearing first
+dotnet_sort_system_directives_first = true
+
+# Prefer this.X except for _fields
+# TODO can we force _ for private fields?
+# TODO elevate severity after code cleanup to warning minimum
+# TODO use language latest
+dotnet_style_qualification_for_field = false:error
+dotnet_style_qualification_for_property = false:error
+dotnet_style_qualification_for_method = false:error
+dotnet_style_qualification_for_event = false:error
+
+# Use language keywords instead of framework type names for type references
+dotnet_style_predefined_type_for_locals_parameters_members = true:error
+dotnet_style_predefined_type_for_member_access = true:error
+
+# Suggest more modern language features when available
+dotnet_style_object_initializer = true:error
+dotnet_style_collection_initializer = true:error
+dotnet_style_explicit_tuple_names = true:error
+dotnet_style_prefer_inferred_anonymous_type_member_names = true:error
+dotnet_style_prefer_inferred_tuple_names = true:error
+dotnet_style_coalesce_expression = true:error
+dotnet_style_null_propagation = true:error
+csharp_style_pattern_matching_over_is_with_cast_check = true:error
+csharp_style_pattern_matching_over_as_with_null_check = true:error
+csharp_style_inlined_variable_declaration = true:error
+csharp_style_deconstructed_variable_declaration = true:error
+csharp_style_pattern_local_over_anonymous_function = true:error
+csharp_style_throw_expression = true:error
+csharp_style_conditional_delegate_call = true:error
+
+dotnet_style_require_accessibility_modifiers = for_non_interface_members:error
+dotnet_style_readonly_field = true:error
+
+# Prefer "var" everywhere
+csharp_style_var_for_built_in_types = true:error
+csharp_style_var_when_type_is_apparent = true:error
+csharp_style_var_elsewhere = true:error
+
+csharp_style_expression_bodied_methods = true:error
+csharp_style_expression_bodied_constructors = true:error
+csharp_style_expression_bodied_operators = true:error
+csharp_style_expression_bodied_properties = true:error
+csharp_style_expression_bodied_indexers = true:error
+csharp_style_expression_bodied_accessors = true:error
+
+csharp_prefer_braces = false:warning
+
+# ---
+# formatting conventions https://docs.microsoft.com/en-us/visualstudio/ide/editorconfig-code-style-settings-reference#formatting-conventions
+
+# Newline settings
+csharp_new_line_before_open_brace = all
+csharp_new_line_before_else = true:error
+csharp_new_line_before_catch = true:error
+csharp_new_line_before_finally = true:error
+csharp_new_line_before_members_in_object_initializers = true
+
+# Indent
+csharp_indent_case_contents = true:error
+csharp_indent_switch_labels = true:error
+csharp_space_after_cast = false:error
+csharp_space_after_keywords_in_control_flow_statements = true:error
+csharp_space_between_method_declaration_parameter_list_parentheses = false:error
+csharp_space_between_method_call_parameter_list_parentheses = false:error
+
+# Wrap
+csharp_preserve_single_line_statements = false:error
+csharp_preserve_single_line_blocks = true:error
+
+# Resharper
+resharper_csharp_braces_for_lock = required_for_multiline
+resharper_csharp_braces_for_using = required_for_multiline
+resharper_csharp_braces_for_while = required_for_multiline
+resharper_csharp_braces_for_foreach = required_for_multiline
+resharper_csharp_braces_for_for = required_for_multiline
+resharper_csharp_braces_for_fixed = required_for_multiline
+resharper_csharp_braces_for_ifelse = required_for_multiline
+
+resharper_csharp_accessor_owner_body = expression_body

--- a/elastic-apm-mongo.sln
+++ b/elastic-apm-mongo.sln
@@ -5,6 +5,22 @@ VisualStudioVersion = 16.0.29209.152
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Elastic.Apm.Mongo", "src\Elastic.Apm.Mongo\Elastic.Apm.Mongo.csproj", "{F4501B59-4F2E-4436-9407-71943A3A7ABC}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Elastic.Apm.Mongo.Tests", "tests\Elastic.Apm.Mongo.Tests\Elastic.Apm.Mongo.Tests.csproj", "{D6CD7340-ECF2-4F15-80F1-4016DB1AC747}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "tests", "tests", "{E5AE4FE2-7D60-4932-AC18-E6BC830DDC05}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Elastic.Apm.Mongo.IntegrationTests", "tests\Elastic.Apm.Mongo.IntegrationTests\Elastic.Apm.Mongo.IntegrationTests.csproj", "{891959DB-7BB7-449C-B55E-15782B838384}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "SolutionItems", "SolutionItems", "{C17F68B2-A613-4E5B-B448-BA0E9F2A631C}"
+ProjectSection(SolutionItems) = preProject
+	.editorconfig = .editorconfig
+	.gitignore = .gitignore
+	azure-pipelines.yml = azure-pipelines.yml
+	GitVersion.yml = GitVersion.yml
+	LICENSE = LICENSE
+	README.md = README.md
+EndProjectSection
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -15,11 +31,23 @@ Global
 		{F4501B59-4F2E-4436-9407-71943A3A7ABC}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{F4501B59-4F2E-4436-9407-71943A3A7ABC}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{F4501B59-4F2E-4436-9407-71943A3A7ABC}.Release|Any CPU.Build.0 = Release|Any CPU
+		{D6CD7340-ECF2-4F15-80F1-4016DB1AC747}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{D6CD7340-ECF2-4F15-80F1-4016DB1AC747}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{D6CD7340-ECF2-4F15-80F1-4016DB1AC747}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{D6CD7340-ECF2-4F15-80F1-4016DB1AC747}.Release|Any CPU.Build.0 = Release|Any CPU
+		{891959DB-7BB7-449C-B55E-15782B838384}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{891959DB-7BB7-449C-B55E-15782B838384}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{891959DB-7BB7-449C-B55E-15782B838384}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{891959DB-7BB7-449C-B55E-15782B838384}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {0BB799C5-DE85-4357-BDC5-398E5F35BB34}
+	EndGlobalSection
+	GlobalSection(NestedProjects) = preSolution
+		{D6CD7340-ECF2-4F15-80F1-4016DB1AC747} = {E5AE4FE2-7D60-4932-AC18-E6BC830DDC05}
+		{891959DB-7BB7-449C-B55E-15782B838384} = {E5AE4FE2-7D60-4932-AC18-E6BC830DDC05}
 	EndGlobalSection
 EndGlobal

--- a/src/Elastic.Apm.Mongo/AssemblyInfo.cs
+++ b/src/Elastic.Apm.Mongo/AssemblyInfo.cs
@@ -1,4 +1,1 @@
 //[assembly: InternalsVisibleTo("Elastic.Apm.Mongo.Tests")]
-
-
-

--- a/src/Elastic.Apm.Mongo/AssemblyInfo.cs
+++ b/src/Elastic.Apm.Mongo/AssemblyInfo.cs
@@ -1,0 +1,4 @@
+//[assembly: InternalsVisibleTo("Elastic.Apm.Mongo.Tests")]
+
+
+

--- a/src/Elastic.Apm.Mongo/CompositeDisposable.cs
+++ b/src/Elastic.Apm.Mongo/CompositeDisposable.cs
@@ -1,0 +1,34 @@
+using System;
+using System.Collections.Generic;
+
+namespace Elastic.Apm.Mongo
+{
+    internal class CompositeDisposable : IDisposable
+    {
+        private readonly List<IDisposable> _disposables = new List<IDisposable>();
+        private readonly object _lock = new object();
+
+        private bool _isDisposed;
+
+        public void Dispose()
+        {
+            if (_isDisposed) return;
+
+            lock (_lock)
+            {
+                if (_isDisposed) return;
+
+                _isDisposed = true;
+                foreach (var d in _disposables) d.Dispose();
+            }
+        }
+
+        public CompositeDisposable Add(IDisposable disposable)
+        {
+            if (_isDisposed) throw new ObjectDisposedException(nameof(CompositeDisposable));
+
+            _disposables.Add(disposable);
+            return this;
+        }
+    }
+}

--- a/src/Elastic.Apm.Mongo/CompositeDisposable.cs
+++ b/src/Elastic.Apm.Mongo/CompositeDisposable.cs
@@ -3,7 +3,7 @@ using System.Collections.Generic;
 
 namespace Elastic.Apm.Mongo
 {
-    internal class CompositeDisposable : IDisposable
+    internal sealed class CompositeDisposable : IDisposable
     {
         private readonly List<IDisposable> _disposables = new List<IDisposable>();
         private readonly object _lock = new object();

--- a/src/Elastic.Apm.Mongo/Constants.cs
+++ b/src/Elastic.Apm.Mongo/Constants.cs
@@ -1,0 +1,14 @@
+namespace Elastic.Apm.Mongo
+{
+    internal static class Constants
+    {
+        internal const string MongoDiagnosticName = "MongoDB.Driver";
+
+        public static class Events
+        {
+            internal const string CommandStart = "CommandStart";
+            internal const string CommandEnd = "CommandEnd";
+            internal const string CommandFail = "CommandFail";
+        }
+    }
+}

--- a/src/Elastic.Apm.Mongo/DiagnosticSource/MongoDiagnosticInitializer.cs
+++ b/src/Elastic.Apm.Mongo/DiagnosticSource/MongoDiagnosticInitializer.cs
@@ -3,7 +3,7 @@ using System.Diagnostics;
 
 namespace Elastic.Apm.Mongo.DiagnosticSource
 {
-    internal class MongoDiagnosticInitializer : IObserver<DiagnosticListener>, IDisposable
+    internal sealed class MongoDiagnosticInitializer : IObserver<DiagnosticListener>, IDisposable
     {
         private readonly IApmAgent _apmAgent;
 

--- a/src/Elastic.Apm.Mongo/DiagnosticSource/MongoDiagnosticInitializer.cs
+++ b/src/Elastic.Apm.Mongo/DiagnosticSource/MongoDiagnosticInitializer.cs
@@ -15,10 +15,12 @@ namespace Elastic.Apm.Mongo.DiagnosticSource
 
         public void OnCompleted()
         {
+            // do nothing because it's not necessary to handle such event from provider
         }
 
         public void OnError(Exception error)
         {
+            // do nothing because it's not necessary to handle such event from provider
         }
 
         public void OnNext(DiagnosticListener value)

--- a/src/Elastic.Apm.Mongo/DiagnosticSource/MongoDiagnosticInitializer.cs
+++ b/src/Elastic.Apm.Mongo/DiagnosticSource/MongoDiagnosticInitializer.cs
@@ -1,0 +1,30 @@
+using System;
+using System.Diagnostics;
+
+namespace Elastic.Apm.Mongo.DiagnosticSource
+{
+    internal class MongoDiagnosticInitializer : IObserver<DiagnosticListener>, IDisposable
+    {
+        private readonly IApmAgent _apmAgent;
+
+        private IDisposable _sourceSubscription;
+
+        internal MongoDiagnosticInitializer(IApmAgent apmAgent) => _apmAgent = apmAgent;
+
+        public void Dispose() => _sourceSubscription?.Dispose();
+
+        public void OnCompleted()
+        {
+        }
+
+        public void OnError(Exception error)
+        {
+        }
+
+        public void OnNext(DiagnosticListener value)
+        {
+            if (value.Name == Constants.MongoDiagnosticName)
+                _sourceSubscription = value.Subscribe(new MongoDiagnosticListener(_apmAgent));
+        }
+    }
+}

--- a/src/Elastic.Apm.Mongo/DiagnosticSource/MongoDiagnosticListener.cs
+++ b/src/Elastic.Apm.Mongo/DiagnosticSource/MongoDiagnosticListener.cs
@@ -48,10 +48,12 @@ namespace Elastic.Apm.Mongo.DiagnosticSource
 
         public void OnError(Exception error)
         {
+            // do nothing because it's not necessary to handle such event from provider
         }
 
         public void OnCompleted()
         {
+            // do nothing because it's not necessary to handle such event from provider
         }
 
         private void HandleCommandStartEvent(CommandStartedEvent @event)

--- a/src/Elastic.Apm.Mongo/DiagnosticSource/MongoDiagnosticListener.cs
+++ b/src/Elastic.Apm.Mongo/DiagnosticSource/MongoDiagnosticListener.cs
@@ -1,0 +1,117 @@
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using Elastic.Apm.Api;
+using Elastic.Apm.Logging;
+using MongoDB.Driver.Core.Events;
+
+namespace Elastic.Apm.Mongo.DiagnosticSource
+{
+    internal class MongoDiagnosticListener : IObserver<KeyValuePair<string, object>>
+    {
+        private readonly IApmAgent _apmAgent;
+        private readonly IApmLogger _logger;
+
+
+        private readonly ConcurrentDictionary<int, ISpan> _processingQueries = new ConcurrentDictionary<int, ISpan>();
+
+        public MongoDiagnosticListener(IApmAgent apmAgent)
+        {
+            _apmAgent = apmAgent;
+            _logger = _apmAgent.Logger;
+
+            //_apmAgent.Logger?.Scoped();
+            // LoggingExtensions is internal
+
+            // {"@timestamp":"2019-08-26T22:06:29.6053995+03:00","level":"Information",
+            // "messageTemplate":"{{{Scope}}} The agent was started without a service name. The automatically discovered service name is {ServiceName}",
+            // "message":"{{Scope}} The agent was started without a service name. The automatically discovered service name is \"ServiceName\"",
+            // "{Scope}":"MicrosoftExtensionsConfig","ServiceName":"ServiceName","SourceContext":"Elastic.Apm"}
+        }
+
+        public void OnNext(KeyValuePair<string, object> value)
+        {
+            switch (value.Key)
+            {
+                case Constants.Events.CommandStart when value.Value is EventPayload<CommandStartedEvent> payload &&
+                                                        _apmAgent.Tracer.CurrentTransaction != null:
+                    HandleCommandStartEvent(payload.Event);
+                    return;
+                case Constants.Events.CommandEnd when value.Value is EventPayload<CommandSucceededEvent> payload:
+                    HandleCommandSucceededEvent(payload.Event);
+                    return;
+                case Constants.Events.CommandFail when value.Value is EventPayload<CommandFailedEvent> payload:
+                    HandleCommandFailedEvent(payload.Event);
+                    return;
+            }
+        }
+
+        public void OnError(Exception error)
+        {
+        }
+
+        public void OnCompleted()
+        {
+        }
+
+        private void HandleCommandStartEvent(CommandStartedEvent @event)
+        {
+            try
+            {
+                var transaction = _apmAgent.Tracer.CurrentTransaction;
+                var currentExecutionSegment = _apmAgent.Tracer.CurrentSpan ?? (IExecutionSegment) transaction;
+                var span = currentExecutionSegment.StartSpan(
+                    @event.CommandName,
+                    ApiConstants.TypeDb,
+                    "mongo");
+
+                if (!_processingQueries.TryAdd(@event.RequestId, span)) return;
+
+                span.Action = ApiConstants.ActionQuery;
+
+                span.Context.Db = new Database
+                {
+                    Statement = @event.Command.ToString(),
+                    Instance = @event.DatabaseNamespace.DatabaseName,
+                    Type = "mongo"
+                };
+            }
+            catch (Exception ex)
+            {
+                //ignore
+                _logger.Log(LogLevel.Error, "Exception was thrown while handling 'command started event''", ex, null);
+            }
+        }
+
+        private void HandleCommandSucceededEvent(CommandSucceededEvent @event)
+        {
+            try
+            {
+                if (!_processingQueries.TryRemove(@event.RequestId, out var span)) return;
+                span.Duration = @event.Duration.TotalMilliseconds;
+                span.End();
+            }
+            catch (Exception ex)
+            {
+                // ignore
+                _logger.Log(LogLevel.Error, "Exception was thrown while handling 'command succeeded event''", ex, null);
+            }
+        }
+
+        private void HandleCommandFailedEvent(CommandFailedEvent @event)
+        {
+            try
+            {
+                if (!_processingQueries.TryRemove(@event.RequestId, out var span)) return;
+                span.Duration = @event.Duration.TotalMilliseconds;
+                span.CaptureException(@event.Failure);
+                span.End();
+            }
+            catch (Exception ex)
+            {
+                // ignore
+                _logger.Log(LogLevel.Error, "Exception was thrown while handling 'command failed event''", ex, null);
+            }
+        }
+    }
+}

--- a/src/Elastic.Apm.Mongo/Elastic.Apm.Mongo.csproj
+++ b/src/Elastic.Apm.Mongo/Elastic.Apm.Mongo.csproj
@@ -11,8 +11,9 @@
     <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
     <RepositoryUrl>https://github.com/vhatsura/elastic-apm-mongo.git</RepositoryUrl>
     <RepositoryType>git</RepositoryType>
-    <Company/>
-    <Product/>
+    <Company />
+    <Product />
+    <LangVersion>8</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Elastic.Apm.Mongo/EventPayload.cs
+++ b/src/Elastic.Apm.Mongo/EventPayload.cs
@@ -1,0 +1,8 @@
+namespace Elastic.Apm.Mongo
+{
+    internal class EventPayload<T>
+    {
+        public EventPayload(T @event) => Event = @event;
+        public T Event { get; }
+    }
+}

--- a/src/Elastic.Apm.Mongo/MongoDiagnosticsSubscriber.cs
+++ b/src/Elastic.Apm.Mongo/MongoDiagnosticsSubscriber.cs
@@ -1,36 +1,31 @@
 ﻿using System;
+using System.Diagnostics;
 using Elastic.Apm.DiagnosticSource;
-using MongoDB.Driver.Core.Events;
+using Elastic.Apm.Mongo.DiagnosticSource;
 
 namespace Elastic.Apm.Mongo
 {
-    public class MongoDiagnosticsSubscriber : IEventSubscriber, IDiagnosticsSubscriber
+    /// <summary>
+    /// </summary>
+    public class MongoDiagnosticsSubscriber : IDiagnosticsSubscriber
     {
-        public static MongoDiagnosticsSubscriber Instance => _instance.Value;
-
-        private static readonly Lazy<MongoDiagnosticsSubscriber> _instance =
-            new Lazy<MongoDiagnosticsSubscriber>(() => new MongoDiagnosticsSubscriber());
-
-        private MongoDiagnosticsSubscriber()
-        {
-        }
-
-        private ReflectionEventSubscriber _subscriber;
-
-        public bool TryGetEventHandler<TEvent>(out Action<TEvent> handler)
-        {
-            handler = null;
-
-            return _subscriber != null && _subscriber.TryGetEventHandler(out handler);
-        }
-
+        /// <summary>
+        ///     Starts listening for MongoDB Driver diagnostic source events
+        /// </summary>
+        /// <param name="components"></param>
+        /// <returns></returns>
         public IDisposable Subscribe(IApmAgent components)
         {
-            var listener = new MongoListener(components);
+            var retVal = new CompositeDisposable();
+            var initializer = new MongoDiagnosticInitializer(components);
 
-            _subscriber = new ReflectionEventSubscriber(listener);
+            retVal.Add(initializer);
 
-            return listener;
+            retVal.Add(DiagnosticListener
+                .AllListeners
+                .Subscribe(initializer));
+
+            return retVal;
         }
     }
 }

--- a/src/Elastic.Apm.Mongo/MongoDiagnosticsSubscriber.cs
+++ b/src/Elastic.Apm.Mongo/MongoDiagnosticsSubscriber.cs
@@ -3,17 +3,18 @@ using System.Diagnostics;
 using Elastic.Apm.DiagnosticSource;
 using Elastic.Apm.Mongo.DiagnosticSource;
 
+// ReSharper disable UnusedMember.Global
+
 namespace Elastic.Apm.Mongo
 {
     /// <summary>
+    ///     A subscriber to events from mongoDB driver diagnostic source.
     /// </summary>
     public class MongoDiagnosticsSubscriber : IDiagnosticsSubscriber
     {
         /// <summary>
-        ///     Starts listening for MongoDB Driver diagnostic source events
+        ///     Starts listening for mongoDB driver diagnostic source events
         /// </summary>
-        /// <param name="components"></param>
-        /// <returns></returns>
         public IDisposable Subscribe(IApmAgent components)
         {
             var retVal = new CompositeDisposable();

--- a/src/Elastic.Apm.Mongo/MongoEventSubscriber.cs
+++ b/src/Elastic.Apm.Mongo/MongoEventSubscriber.cs
@@ -1,0 +1,26 @@
+using System;
+using MongoDB.Driver.Core.Events;
+
+namespace Elastic.Apm.Mongo
+{
+    /// <inheritdoc cref="IEventSubscriber" />
+    public class MongoEventSubscriber : IEventSubscriber
+    {
+        private readonly ReflectionEventSubscriber _subscriber;
+
+        /// <summary>
+        /// </summary>
+        public MongoEventSubscriber() => _subscriber = new ReflectionEventSubscriber(new MongoListener());
+
+        /// <summary>
+        ///     Tries to get an event handler for an event of type <typeparamref name="TEvent" />.
+        /// </summary>
+        /// <param name="handler">The handler.</param>
+        /// <typeparam name="TEvent">The type of the event.</typeparam>
+        /// <returns>
+        ///     <c>true</c> if this subscriber has provided an event handler; otherwise <c>false</c>.
+        /// </returns>
+        public bool TryGetEventHandler<TEvent>(out Action<TEvent> handler) =>
+            _subscriber.TryGetEventHandler(out handler);
+    }
+}

--- a/src/Elastic.Apm.Mongo/MongoEventSubscriber.cs
+++ b/src/Elastic.Apm.Mongo/MongoEventSubscriber.cs
@@ -4,11 +4,13 @@ using MongoDB.Driver.Core.Events;
 namespace Elastic.Apm.Mongo
 {
     /// <inheritdoc cref="IEventSubscriber" />
+    // ReSharper disable once UnusedMember.Global
     public class MongoEventSubscriber : IEventSubscriber
     {
         private readonly ReflectionEventSubscriber _subscriber;
 
         /// <summary>
+        ///     Creates instance of <see cref="MongoEventSubscriber" /> class.
         /// </summary>
         public MongoEventSubscriber() => _subscriber = new ReflectionEventSubscriber(new MongoListener());
 

--- a/src/Elastic.Apm.Mongo/MongoListener.cs
+++ b/src/Elastic.Apm.Mongo/MongoListener.cs
@@ -1,102 +1,31 @@
-using System;
-using System.Collections.Concurrent;
-using Elastic.Apm.Api;
-using Elastic.Apm.Logging;
+using System.Diagnostics;
 using MongoDB.Driver.Core.Events;
+
+// ReSharper disable UnusedMember.Global
 
 namespace Elastic.Apm.Mongo
 {
-    public class MongoListener : IDisposable
+    internal class MongoListener
     {
-        private readonly IApmAgent _apmAgent;
-        private readonly IApmLogger _logger;
-
-        private readonly ConcurrentDictionary<int, ISpan> _processingQueries = new ConcurrentDictionary<int, ISpan>();
-
-        public MongoListener(IApmAgent apmAgent)
-        {
-            _apmAgent = apmAgent;
-            _logger = _apmAgent.Logger;
-            //_apmAgent.Logger?.Scoped();
-            // LoggingExtensions is internal
-
-            // {"@timestamp":"2019-08-26T22:06:29.6053995+03:00","level":"Information",
-            // "messageTemplate":"{{{Scope}}} The agent was started without a service name. The automatically discovered service name is {ServiceName}",
-            // "message":"{{Scope}} The agent was started without a service name. The automatically discovered service name is \"ServiceName\"",
-            // "{Scope}":"MicrosoftExtensionsConfig","ServiceName":"ServiceName","SourceContext":"Elastic.Apm"}
-        }
+        private static readonly System.Diagnostics.DiagnosticSource MongoLogger =
+            new DiagnosticListener(Constants.MongoDiagnosticName);
 
         public void Handle(CommandStartedEvent @event)
         {
-            try
-            {
-                var transaction = _apmAgent.Tracer.CurrentTransaction;
-                if (transaction == null)
-                {
-                    return;
-                }
-
-                var currentExecutionSegment = _apmAgent.Tracer.CurrentSpan ?? (IExecutionSegment) transaction;
-                var span = currentExecutionSegment.StartSpan(
-                    @event.CommandName,
-                    ApiConstants.TypeDb,
-                    "mongo");
-
-                _processingQueries.TryAdd(@event.RequestId, span);
-
-                span.Action = ApiConstants.ActionQuery;
-
-                span.Context.Db = new Database
-                {
-                    Statement = @event.Command.ToString(),
-                    Instance = @event.ConnectionId.ServerId.EndPoint.ToString(),
-                    Type = "mongo"
-                };
-            }
-            catch (Exception ex)
-            {
-                //ignore
-            }
+            if (MongoLogger.IsEnabled(Constants.Events.CommandStart))
+                MongoLogger.Write(Constants.Events.CommandStart, new EventPayload<CommandStartedEvent>(@event));
         }
 
         public void Handle(CommandSucceededEvent @event)
         {
-            try
-            {
-                if (_processingQueries.TryRemove(@event.RequestId, out var span))
-                {
-                    span.Duration = @event.Duration.TotalMilliseconds;
-                }
-
-                span.End();
-            }
-            catch (Exception ex)
-            {
-                // ignore
-            }
-           
+            if (MongoLogger.IsEnabled(Constants.Events.CommandEnd))
+                MongoLogger.Write(Constants.Events.CommandEnd, new EventPayload<CommandSucceededEvent>(@event));
         }
 
         public void Handle(CommandFailedEvent @event)
         {
-            try
-            {
-                if (_processingQueries.TryRemove(@event.RequestId, out var span))
-                {
-                    span.Duration = @event.Duration.TotalMilliseconds;
-                }
-
-                span.CaptureException(@event.Failure);
-            }
-            catch (Exception ex)
-            {
-                // ignore
-            }
-            
-        }
-
-        public void Dispose()
-        {
+            if (MongoLogger.IsEnabled(Constants.Events.CommandFail))
+                MongoLogger.Write(Constants.Events.CommandFail, new EventPayload<CommandFailedEvent>(@event));
         }
     }
 }

--- a/tests/Elastic.Apm.Mongo.IntegrationTests/Elastic.Apm.Mongo.IntegrationTests.csproj
+++ b/tests/Elastic.Apm.Mongo.IntegrationTests/Elastic.Apm.Mongo.IntegrationTests.csproj
@@ -8,6 +8,7 @@
     </PropertyGroup>
 
     <ItemGroup>
+        <PackageReference Include="coverlet.msbuild" Version="2.6.3" />
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.2.0" />
         <PackageReference Include="Mongo2Go" Version="2.2.11" />
         <PackageReference Include="MongoDB.Driver" Version="2.9.1" />

--- a/tests/Elastic.Apm.Mongo.IntegrationTests/Elastic.Apm.Mongo.IntegrationTests.csproj
+++ b/tests/Elastic.Apm.Mongo.IntegrationTests/Elastic.Apm.Mongo.IntegrationTests.csproj
@@ -1,0 +1,23 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+    <PropertyGroup>
+
+        <IsPackable>false</IsPackable>
+
+        <TargetFramework>netcoreapp3.0</TargetFramework>
+    </PropertyGroup>
+
+    <ItemGroup>
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.2.0" />
+        <PackageReference Include="Mongo2Go" Version="2.2.11" />
+        <PackageReference Include="MongoDB.Driver" Version="2.9.1" />
+        <PackageReference Include="xunit" Version="2.4.1" />
+        <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1" />
+        <PackageReference Include="coverlet.collector" Version="1.0.1" />
+    </ItemGroup>
+
+    <ItemGroup>
+      <ProjectReference Include="..\..\src\Elastic.Apm.Mongo\Elastic.Apm.Mongo.csproj" />
+    </ItemGroup>
+
+</Project>

--- a/tests/Elastic.Apm.Mongo.IntegrationTests/Fixture/IMongoConfiguration.cs
+++ b/tests/Elastic.Apm.Mongo.IntegrationTests/Fixture/IMongoConfiguration.cs
@@ -1,0 +1,17 @@
+using System.Threading.Tasks;
+using MongoDB.Driver;
+
+namespace Elastic.Apm.Mongo.IntegrationTests.Fixture
+{
+    public interface IMongoConfiguration<TDocument>
+    {
+        string DatabaseName { get; }
+
+        string CollectionName { get; }
+        MongoClient GetMongoClient(string connectionString);
+
+        Task InitializeAsync(IMongoCollection<TDocument> collection);
+
+        Task DisposeAsync(IMongoCollection<TDocument> collection);
+    }
+}

--- a/tests/Elastic.Apm.Mongo.IntegrationTests/Fixture/MongoFixture.cs
+++ b/tests/Elastic.Apm.Mongo.IntegrationTests/Fixture/MongoFixture.cs
@@ -1,0 +1,34 @@
+using System;
+using System.Threading.Tasks;
+using Mongo2Go;
+using MongoDB.Driver;
+using Xunit;
+
+namespace Elastic.Apm.Mongo.IntegrationTests.Fixture
+{
+    public class MongoFixture<TConfiguration, TDocument> : IAsyncLifetime, IDisposable
+        where TConfiguration : IMongoConfiguration<TDocument>, new()
+    {
+        private readonly TConfiguration _configuration;
+        private readonly MongoDbRunner _runner;
+
+        public MongoFixture()
+        {
+            _configuration = new TConfiguration();
+            _runner = MongoDbRunner.Start();
+
+
+            var mongoClient = _configuration.GetMongoClient(_runner.ConnectionString);
+            Collection = mongoClient.GetDatabase(_configuration.DatabaseName)
+                .GetCollection<TDocument>(_configuration.CollectionName);
+        }
+
+        public IMongoCollection<TDocument> Collection { get; }
+
+        public Task InitializeAsync() => _configuration.InitializeAsync(Collection);
+
+        public Task DisposeAsync() => _configuration.DisposeAsync(Collection);
+
+        public void Dispose() => _runner?.Dispose();
+    }
+}

--- a/tests/Elastic.Apm.Mongo.IntegrationTests/Mocks/ConfigurationReader.cs
+++ b/tests/Elastic.Apm.Mongo.IntegrationTests/Mocks/ConfigurationReader.cs
@@ -1,0 +1,22 @@
+using System;
+using System.Collections.Generic;
+using Elastic.Apm.Config;
+using Elastic.Apm.Logging;
+
+namespace Elastic.Apm.Mongo.IntegrationTests.Mocks
+{
+    public class ConfigurationReader : IConfigurationReader
+    {
+        public ConfigurationReader(Uri apmServerUrl) => ServerUrls = new[] {apmServerUrl};
+
+        public bool CaptureHeaders => false;
+        public LogLevel LogLevel => LogLevel.Error;
+        public double MetricsIntervalInMilliseconds => TimeSpan.FromSeconds(5).TotalMilliseconds;
+        public string SecretToken => null;
+        public IReadOnlyList<Uri> ServerUrls { get; }
+        public string ServiceName => "Elastic.Apm.MongoTests";
+        public double SpanFramesMinDurationInMilliseconds => 0;
+        public int StackTraceLimit => 0;
+        public double TransactionSampleRate => 1.0;
+    }
+}

--- a/tests/Elastic.Apm.Mongo.IntegrationTests/Mocks/MockPayloadSender.cs
+++ b/tests/Elastic.Apm.Mongo.IntegrationTests/Mocks/MockPayloadSender.cs
@@ -1,0 +1,30 @@
+using System.Collections.Concurrent;
+using Elastic.Apm.Api;
+using Elastic.Apm.Report;
+
+namespace Elastic.Apm.Mongo.IntegrationTests.Mocks
+{
+    public class MockPayloadSender : IPayloadSender
+    {
+        public ConcurrentQueue<IError> ErrorsQueue { get; } = new ConcurrentQueue<IError>();
+        public ConcurrentQueue<ITransaction> TransactionsQueue { get; } = new ConcurrentQueue<ITransaction>();
+        public ConcurrentQueue<ISpan> SpansQueue { get; } = new ConcurrentQueue<ISpan>();
+
+        public void QueueError(IError error) => ErrorsQueue.Enqueue(error);
+
+        public void QueueTransaction(ITransaction transaction) => TransactionsQueue.Enqueue(transaction);
+
+        public void QueueSpan(ISpan span) => SpansQueue.Enqueue(span);
+
+        public void QueueMetrics(IMetricSet metrics)
+        {
+        }
+
+        public void DropQueues()
+        {
+            ErrorsQueue.Clear();
+            TransactionsQueue.Clear();
+            SpansQueue.Clear();
+        }
+    }
+}

--- a/tests/Elastic.Apm.Mongo.IntegrationTests/MongoApmTests.cs
+++ b/tests/Elastic.Apm.Mongo.IntegrationTests/MongoApmTests.cs
@@ -1,0 +1,128 @@
+using System;
+using System.Linq;
+using System.Threading.Tasks;
+using Elastic.Apm.Api;
+using Elastic.Apm.Mongo.IntegrationTests.Fixture;
+using Elastic.Apm.Mongo.IntegrationTests.Mocks;
+using MongoDB.Bson;
+using MongoDB.Driver;
+using Xunit;
+
+namespace Elastic.Apm.Mongo.IntegrationTests
+{
+    public class MongoApmTests : IClassFixture<MongoFixture<MongoApmTests.MongoConfiguration, BsonDocument>>,
+        IDisposable
+    {
+        public MongoApmTests(MongoFixture<MongoConfiguration, BsonDocument> fixture)
+        {
+            _documents = fixture.Collection;
+            _payloadSender = new MockPayloadSender();
+
+            var config =
+                new AgentComponents(configurationReader: new ConfigurationReader(new Uri("http://localhost:8200")),
+                    payloadSender: _payloadSender);
+
+            var apmAgentType = typeof(IApmAgent).Assembly.GetType("Elastic.Apm.ApmAgent");
+            _agent = (IApmAgent) apmAgentType.GetConstructors().First().Invoke(new object[] {config});
+            _agent.Subscribe(new MongoDiagnosticsSubscriber());
+        }
+
+        public void Dispose() => (_agent as IDisposable)?.Dispose();
+
+        private readonly IApmAgent _agent;
+
+        private const string DatabaseName = "elastic-apm-mongo";
+
+        public class MongoConfiguration : IMongoConfiguration<BsonDocument>
+        {
+            public MongoClient GetMongoClient(string connectionString)
+            {
+                var mongoClientSettings = MongoClientSettings.FromConnectionString(connectionString);
+                mongoClientSettings.ClusterConfigurator = builder => builder.Subscribe(new MongoEventSubscriber());
+
+                return new MongoClient(mongoClientSettings);
+            }
+
+            string IMongoConfiguration<BsonDocument>.DatabaseName => DatabaseName;
+            public string CollectionName => "documents";
+
+            public Task InitializeAsync(IMongoCollection<BsonDocument> collection) =>
+                collection.InsertManyAsync(Enumerable.Range(0, 10_000).Select(x => new BsonDocument("_id", x)));
+
+            public Task DisposeAsync(IMongoCollection<BsonDocument> collection) =>
+                collection.Database.DropCollectionAsync(CollectionName);
+        }
+
+        private readonly IMongoCollection<BsonDocument> _documents;
+
+        private readonly MockPayloadSender _payloadSender;
+
+        [Fact]
+        public async Task ApmAgent_ShouldCorrectly()
+        {
+            // Arrange
+            var transaction = _agent.Tracer.StartTransaction("elastic-apm-mongo", ApiConstants.TypeDb);
+
+            // Act
+            var docs = await _documents
+                .Find(Builders<BsonDocument>.Filter.Empty)
+                .Project(Builders<BsonDocument>.Projection.ElemMatch("filter", FilterDefinition<BsonDocument>.Empty))
+                .ToListAsync();
+
+            transaction.End();
+
+            // Assert
+            Assert.Single(_payloadSender.TransactionsQueue);
+            Assert.True(_payloadSender.TransactionsQueue.TryPeek(out var capturedTransaction));
+
+            Assert.All(_payloadSender.SpansQueue, span =>
+            {
+                Assert.Equal(capturedTransaction.Id, span.TransactionId);
+                Assert.Equal(DatabaseName, span.Context.Db.Instance);
+                Assert.Equal(ApiConstants.TypeDb, span.Type);
+            });
+
+            Assert.All(_payloadSender.SpansQueue, span => { Assert.Equal(capturedTransaction.Id, span.ParentId); });
+        }
+
+        [Fact]
+        public async Task ApmAgent_ShouldCorrectlyCaptureSpanAndError_WhenMongoCommandFailed()
+        {
+            // Arrange
+            var transaction = _agent.Tracer.StartTransaction("elastic-apm-mongo", ApiConstants.TypeDb);
+
+            // Act
+            try
+            {
+                await _documents.Database.RunCommandAsync(new JsonCommand<BsonDocument>("{}"));
+            }
+            catch
+            {
+                // ignore
+            }
+
+            transaction.End();
+
+            // Assert
+            Assert.Single(_payloadSender.TransactionsQueue);
+            Assert.True(_payloadSender.TransactionsQueue.TryPeek(out var capturedTransaction));
+
+
+            Assert.Single(_payloadSender.SpansQueue);
+            Assert.True(_payloadSender.SpansQueue.TryPeek(out var capturedSpan));
+
+            Assert.Equal(capturedTransaction.Id, capturedSpan.TransactionId);
+            Assert.Equal(DatabaseName, capturedSpan.Context.Db.Instance);
+            Assert.Equal(ApiConstants.TypeDb, capturedSpan.Type);
+
+
+            Assert.Single(_payloadSender.ErrorsQueue);
+            Assert.True(_payloadSender.ErrorsQueue.TryPeek(out var capturedError));
+
+            Assert.Equal(capturedTransaction.Id,
+                capturedError.GetType().GetProperty("TransactionId")?.GetValue(capturedError)?.ToString());
+            Assert.Equal(capturedSpan.Id,
+                capturedError.GetType().GetProperty("ParentId")?.GetValue(capturedError)?.ToString());
+        }
+    }
+}

--- a/tests/Elastic.Apm.Mongo.Tests/Elastic.Apm.Mongo.Tests.csproj
+++ b/tests/Elastic.Apm.Mongo.Tests/Elastic.Apm.Mongo.Tests.csproj
@@ -9,6 +9,7 @@
 
     <ItemGroup>
         <PackageReference Include="AutoFixture.Xunit2" Version="4.11.0" />
+        <PackageReference Include="coverlet.msbuild" Version="2.6.3" />
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.2.0" />
         <PackageReference Include="Moq" Version="4.13.0" />
         <PackageReference Include="xunit" Version="2.4.1" />

--- a/tests/Elastic.Apm.Mongo.Tests/Elastic.Apm.Mongo.Tests.csproj
+++ b/tests/Elastic.Apm.Mongo.Tests/Elastic.Apm.Mongo.Tests.csproj
@@ -1,0 +1,23 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+    <PropertyGroup>
+
+        <IsPackable>false</IsPackable>
+
+        <TargetFrameworks>net461;netcoreapp3.0</TargetFrameworks>
+    </PropertyGroup>
+
+    <ItemGroup>
+        <PackageReference Include="AutoFixture.Xunit2" Version="4.11.0" />
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.2.0" />
+        <PackageReference Include="Moq" Version="4.13.0" />
+        <PackageReference Include="xunit" Version="2.4.1" />
+        <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1" />
+        <PackageReference Include="coverlet.collector" Version="1.0.1" />
+    </ItemGroup>
+
+    <ItemGroup>
+      <ProjectReference Include="..\..\src\Elastic.Apm.Mongo\Elastic.Apm.Mongo.csproj" />
+    </ItemGroup>
+
+</Project>


### PR DESCRIPTION
now listeners are divided to two parts: event subscriber for mongo events and pushing them to DiagnosticsSource, listener which reads data from diagnostic source